### PR TITLE
Updating feed.rss to include a webp enclosure

### DIFF
--- a/feed.rss
+++ b/feed.rss
@@ -27,6 +27,8 @@ sitemap:
 					<enclosure type="image/png" url="{{ post.image | absolute_url }}" />
 				{% elsif image_ext == "jpg" %}
 					<enclosure type="image/jpeg" url="{{ post.image | absolute_url }}" />
+				{% elsif image_ext == "webp" %}
+					<enclosure type="image/webp" url="{{ post.image | absolute_url }}" />
 				{% endif %}
 			{% endif %}
 			{% for tagname in post.tags %}


### PR DESCRIPTION
The monthly blog post for May does not include an image in the feed, because it's a webp image.

This can be observed via the RSS feed: https://blog.minetest.net/feed.rss but also something I noticed during development of my launcher.