### PR TITLE
Fix broken links in 2022-03-27-March.md

### DIFF
--- a/_posts/2022-03-27-March.md
+++ b/_posts/2022-03-27-March.md
@@ -18,7 +18,7 @@ builds:
     caption: >
       "MSS Faraday: Boldly going above Y = 20000", by <a href="https://content.luanti.org/users/BuckarooBanzay/">BuckarooBanzai</a>
 
-      You can get the schematic <a href="https://blockexchange.minetest.land/api/static/schema/BuckarooBanzai/mss_faraday">here</a>.
+      You can get the schematic <a href="https://blockexchange.minetest.ch/schema/BuckarooBanzai/mss_faraday">here</a>.
 
   - src: /static/blog/2022_March/atlas.png?raw=true
     caption: Atlas by <a href="https://content.luanti.org/users/GreenXenith/">GreenXenith</a>


### PR DESCRIPTION
BlockExchange had its domain changed at some point, and the old domain is currently running a phishing attack according to OpenDNS. D: (Also apparenrly the URL scheme changed.)